### PR TITLE
fix: put credentials in .env file

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,0 +1,8 @@
+# All the credentials would place here
+
+# Postgres databse configurations
+POSTGRES_HOST=
+POSTGRES_DB=
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+POSTGRES_PORT=

--- a/configs/private/privateConf.dev.yml
+++ b/configs/private/privateConf.dev.yml
@@ -1,8 +1,0 @@
-# All the credentials would place here
-
-# Postgres databse configurations
-POSTGRES_HOST: 127.0.0.1
-POSTGRES_DB: devdb
-POSTGRES_USER: devuser
-POSTGRES_PASSWORD: changeme
-POSTGRES_PORT: 5432

--- a/configs/private/privateConf.env
+++ b/configs/private/privateConf.env
@@ -1,8 +1,0 @@
-# All the credentials would place here
-
-# Postgres databse configurations
-POSTGRES_HOST=127.0.0.1
-POSTGRES_DB=devdb
-POSTGRES_USER=devuser
-POSTGRES_PASSWORD=changeme
-POSTGRES_PORT=5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,14 +17,12 @@ services:
       sh -c "python manage.py wait_for_db &&
              python manage.py migrate &&
              python manage.py runserver 0.0.0.0:8181"
-    env_file:
-      - path: ./configs/private/privateConf.dev.yml
-        required: true
     environment:
       - DB_HOST=db
-      - DB_NAME=devdb
-      - DB_USER=devuser
-      - DB_PASS=changeme
+      - DB_NAME=${POSTGRES_DB}
+      - DB_USER=${POSTGRES_USER}
+      - DB_PASS=${POSTGRES_PASSWORD}
+      - DB_PORT=${POSTGRES_PORT}
     depends_on:
       - db
 
@@ -32,13 +30,10 @@ services:
     image: postgres:16-alpine
     volumes:
       - dev-db-data-ticket:/var/lib/postgresql/data
-    env_file:
-      - path: ./configs/private/privateConf.dev.yml
-        required: true
     environment:
-      - POSTGRES_DB=devdb
-      - POSTGRES_USER=devuser
-      - POSTGRES_PASSWORD=changeme
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
 
 volumes:
   dev-db-data-ticket:


### PR DESCRIPTION
Database credentials should be placed in a **.env** file next to [Dockerfile](Dockerfile). there is a [.example.env](.example.env) file in the repo which shows the structure of this file.